### PR TITLE
Fix RequirementsChecker to use default db ports if none specified.

### DIFF
--- a/server/requirements/RequirementsChecker.php
+++ b/server/requirements/RequirementsChecker.php
@@ -405,7 +405,7 @@ class RequirementsChecker
             $this->dbCreds['password'] = $configService->get('password', 'db');
             $this->dbCreds['database'] = $configService->get('database', 'db');
             $this->dbCreds['driver'] = $configService->get('driver', 'db');
-            $this->dbCreds['port'] = $configService->get('port', 'db');
+            $this->dbCreds['port'] = $configService->getDbPort();
 
             return true;
         } else {


### PR DESCRIPTION
RequirementsChecker was not using `getDbPort()` to assign the database port to `dbCreds` causing the value to be set to an empty string instead of the defaults. The condition would fail and the user got an error message suggesting that db credentials were incorrectly set.

This change will use the default ports (`:3306` or `:5432`) if the user has not manually set the db port in `/config/db.php`. The condition passes now.

This PR partially fixes https://github.com/craftcms/cms/issues/1333.

_work still needs to be done to address the postgres error in https://github.com/craftcms/cms/issues/1333_