### PR TITLE
Fix 404ing links

### DIFF
--- a/server/requirements/requirements.php
+++ b/server/requirements/requirements.php
@@ -170,13 +170,13 @@ $requirements = array_merge($requirements, array(
         'name' => 'proc_close()',
         'mandatory' => false,
         'condition' => function_exists('proc_close'),
-        'memo' => 'The <a target="_blank" href="https://secure.php.net/manual/en/function.proc_close.php">proc_close()</a> function is required for Plugin Store operations as well as sending emails.',
+        'memo' => 'The <a target="_blank" href="https://secure.php.net/manual/en/function.proc-close.php">proc_close()</a> function is required for Plugin Store operations as well as sending emails.',
     ),
     array(
         'name' => 'proc_terminate()',
         'mandatory' => false,
         'condition' => function_exists('proc_terminate'),
-        'memo' => 'The <a target="_blank" href="https://secure.php.net/manual/en/function.proc_terminate.php">proc_terminate()</a> function is required for Plugin Store operations as well as sending emails.',
+        'memo' => 'The <a target="_blank" href="https://secure.php.net/manual/en/function.proc-terminate.php">proc_terminate()</a> function is required for Plugin Store operations as well as sending emails.',
     ),
     array(
         'name' => 'allow_url_fopen',


### PR DESCRIPTION
Some links that point to documentation on PHP.net don't work. This commit fixes these broken links.

Have checked all the other links in this file and the rest seem fine.