### PR TITLE
Add 1MB to current memory limit before executing ini_set call

### DIFF
--- a/server/requirements/RequirementsChecker.php
+++ b/server/requirements/RequirementsChecker.php
@@ -432,8 +432,16 @@ class RequirementsChecker
     function iniSetRequirement()
     {
         $oldValue = ini_get('memory_limit');
+
+        $setValue = '442M'; // A random PHP memory limit value.
+        if ($oldValue !== '-1'){
+            // When the old value is not equal to '-1', add 1MB to the limit set at the moment.
+            $bytes = $this->getByteSize($oldValue) + $this->getByteSize('1M');
+            $setValue = sprintf('%sM', $bytes / 1024 ** 2);
+        }
+
         set_error_handler(array($this, 'muteErrorHandler'));
-        $result = ini_set('memory_limit', '442M');
+        $result = ini_set('memory_limit', $setValue);
         $newValue = ini_get('memory_limit');
         ini_set('memory_limit', $oldValue);
         restore_error_handler();

--- a/server/requirements/RequirementsChecker.php
+++ b/server/requirements/RequirementsChecker.php
@@ -437,7 +437,7 @@ class RequirementsChecker
         if ($oldValue !== '-1'){
             // When the old value is not equal to '-1', add 1MB to the limit set at the moment.
             $bytes = $this->getByteSize($oldValue) + $this->getByteSize('1M');
-            $setValue = sprintf('%sM', $bytes / 1024 ** 2);
+            $setValue = sprintf('%sM', $bytes / (1024 * 1024));
         }
 
         set_error_handler(array($this, 'muteErrorHandler'));


### PR DESCRIPTION
The ini_set requirement check will fail when the memory_limit is set to 442M.
This pull request will get the current value and add 1M before setting the new value.
By doing so, we're sure that the oldValue is never equal to the newValue (which would show a warning in the system report).
When the oldValue is set to -1, it will just try to set the new memory_limit to the magic random number 442M ;-) 