### PR TITLE
Query database to retrieve mysql-version to support mariadb and other…

### DIFF
--- a/server/requirements/requirements.php
+++ b/server/requirements/requirements.php
@@ -24,7 +24,12 @@ switch ($this->dbDriver) {
             'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/ref.pdo-mysql.php">PDO MySQL</a> extension is required.'
         );
         if ($conn !== false) {
-            $version = $conn->getAttribute(PDO::ATTR_SERVER_VERSION);
+            $result = $conn->query('SELECT VERSION() as mysql_version')->fetch();
+            if (isset($result[0])) {
+                $version = $result[0];
+            } else {
+                $version = $conn->getAttribute(PDO::ATTR_SERVER_VERSION);
+            }
             if (preg_match('/[\d.]+-([\d.]+)-\bMariaDB\b/', $version, $match)) {
                 $name = 'MariaDB';
                 $version = $match[1];


### PR DESCRIPTION
… distros with non-standard ports, attributes etc.

### Description
We had an issue on Azure, that in certain conditions the version retrieved from PDO::ATTR_SERVER_VERSION was completely wrong, not even a mariadb version.
That PR would change the version check here to a query directly on the database to get the version.
If that fails, it would fallback to PDO::ATTR_SERVER_VERSIO

### Related issues

