### PR TITLE
2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for Craft CMS Server Check
 
+## 2.1.3 - 2022-02-15
+
+### Added
+- Added the BCMath extension as a requirement.
+
 ## 2.1.2 - 2022-02-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for Craft CMS Server Check
 
+## 2.1.4 - 2022-04-16
+
+### Added
+- Added checks for relying on the default `@web` alias.
+
 ## 2.1.3 - 2022-02-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for Craft CMS Server Check
 
+- 2.0.1 - 2021-12-07
+
+### Added
+- There is now an explicit check for MariaDB, and it requires version 10.2.7 or higher. 
+
 ## 1.2.1 - 2021-05-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for Craft CMS Server Check
 
+## 2.1.1 - 2022-02-10
+
+### Fixed
+- Fixed a bug where the MariaDB version wasn’t always being parsed correctly. ([craftcms/cms#10456](https://github.com/craftcms/cms/issues/10456))
+
 ## 2.1.0 - 2022-02-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for Craft CMS Server Check
 
+## Unreleased
+
+### Changed
+- Bumped the PHP requirement to 8.0 for Craft 4.0.
+- Bumped the PostgreSQL requirement to 10.0 for Craft 4.0.
+
 ## 2.0.1 - 2021-12-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for Craft CMS Server Check
 
+## 2.1.2 - 2022-02-14
+
+### Changed
+- Bumped the PHP requirement to 8.0.2+.
+
 ## 2.1.1 - 2022-02-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - Bumped the PHP requirement to 8.0 for Craft 4.0.
 - Bumped the PostgreSQL requirement to 10.0 for Craft 4.0.
+- The `intl` extension is now required for Craft 4.0.
 
 ## 2.0.1 - 2021-12-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for Craft CMS Server Check
 
-- 2.0.1 - 2021-12-07
+## 2.0.1 - 2021-12-07
 
 ### Added
 - There is now an explicit check for MariaDB, and it requires version 10.2.7 or higher. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for Craft CMS Server Check
 
-## Unreleased
+## 2.1.0 - 2022-02-09
 
 ### Changed
 - Bumped the PHP requirement to 8.0 for Craft 4.0.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Craft Server Check
 
-This script checks if a web server meets the minimum requirements to run a Craft 3 installation.
+This script checks if a web server meets the minimum requirements to run a Craft 4 installation.
 
 ## Usage
 

--- a/server/requirements/RequirementsChecker.php
+++ b/server/requirements/RequirementsChecker.php
@@ -51,6 +51,7 @@ class RequirementsChecker
     var $result;
 
     var $requiredMySqlVersion = '5.7.8';
+    var $requiredMariaDbVersion = '10.2.7';
     var $requiredPgSqlVersion = '9.5';
 
     /**

--- a/server/requirements/RequirementsChecker.php
+++ b/server/requirements/RequirementsChecker.php
@@ -451,20 +451,20 @@ class RequirementsChecker
         // ini_set can return false or an empty string depending on your php version / FastCGI.
         // If ini_set has been disabled in php.ini, the value will be null because of our muted error handler
         if ($result === null) {
-            $memo = 'It looks like <a rel="noopener" target="_blank" href="http://php.net/manual/en/function.ini-set.php">ini_set</a> has been disabled in your <code>php.ini</code> file. Craft requires that to operate.';
+            $memo = 'It looks like <a rel="noopener" target="_blank" href="https://php.net/manual/en/function.ini-set.php">ini_set</a> has been disabled in your <code>php.ini</code> file. Craft requires that to operate.';
             $condition = false;
         }
 
         // ini_set can return false or an empty string or the current value of memory_limit depending on your php
         // version and FastCGI. Regard, calling it didn't work, but there was no error.
         else if ($result === false || $result === '' || $result === $newValue) {
-            $memo = 'It appears calls to <a rel="noopener" target="_blank" href="http://php.net/manual/en/function.ini-set.php">ini_set</a> are not working for Craft. You may need to increase some settings in your php.ini file such as <a rel="noopener" target="_blank" href="http://php.net/manual/en/ini.core.php#ini.memory-limit">memory_limit</a> and <a rel="noopener" target="_blank" href="http://php.net/manual/en/info.configuration.php#ini.max-execution-time">max_execution_time</a> for long running operations like updating and asset transformations.';
+            $memo = 'It appears calls to <a rel="noopener" target="_blank" href="https://php.net/manual/en/function.ini-set.php">ini_set</a> are not working for Craft. You may need to increase some settings in your php.ini file such as <a rel="noopener" target="_blank" href="https://php.net/manual/en/ini.core.php#ini.memory-limit">memory_limit</a> and <a rel="noopener" target="_blank" href="https://php.net/manual/en/info.configuration.php#ini.max-execution-time">max_execution_time</a> for long running operations like updating and asset transformations.';
 
             // Set mandatory to false here so it's not a "fatal" error, but will be treated as a warning.
             $mandatory = false;
             $condition = false;
         } else {
-            $memo = 'Calls to <a rel="noopener" target="_blank" href="http://php.net/manual/en/function.ini-set.php">ini_set</a> are working correctly.';
+            $memo = 'Calls to <a rel="noopener" target="_blank" href="https://php.net/manual/en/function.ini-set.php">ini_set</a> are working correctly.';
             $condition = true;
         }
 
@@ -479,7 +479,7 @@ class RequirementsChecker
     /**
      * @return array
      *
-     * @see http://php.net/manual/en/ini.core.php#ini.memory-limit
+     * @see https://php.net/manual/en/ini.core.php#ini.memory-limit
      */
     function memoryLimitRequirement()
     {
@@ -500,7 +500,7 @@ class RequirementsChecker
     /**
      * @return array
      *
-     * @see http://php.net/manual/en/info.configuration.php#ini.max-execution-time
+     * @see https://php.net/manual/en/info.configuration.php#ini.max-execution-time
      */
     function maxExecutionTimeRequirement()
     {

--- a/server/requirements/RequirementsChecker.php
+++ b/server/requirements/RequirementsChecker.php
@@ -12,7 +12,7 @@ if (version_compare(PHP_VERSION, '4.3', '<')) {
 
 /**
  * The Craft Requirement Checker allows checking if the current system meets the minimum requirements for running a
- * Craft 3 application.
+ * Craft 4 application.
  *
  * This class allows rendering of the requirement report through a web browser or command line interface.
  *
@@ -52,7 +52,7 @@ class RequirementsChecker
 
     var $requiredMySqlVersion = '5.7.8';
     var $requiredMariaDbVersion = '10.2.7';
-    var $requiredPgSqlVersion = '9.5';
+    var $requiredPgSqlVersion = '10.0';
 
     /**
      * Check the given requirements, collecting results into internal field.

--- a/server/requirements/RequirementsChecker.php
+++ b/server/requirements/RequirementsChecker.php
@@ -50,7 +50,7 @@ class RequirementsChecker
 
     var $result;
 
-    var $requiredMySqlVersion = '5.5.0';
+    var $requiredMySqlVersion = '5.7.8';
     var $requiredPgSqlVersion = '9.5';
 
     /**

--- a/server/requirements/requirements.php
+++ b/server/requirements/requirements.php
@@ -21,7 +21,7 @@ switch ($this->dbDriver) {
             'name' => 'PDO MySQL extension',
             'mandatory' => true,
             'condition' => extension_loaded('pdo_mysql'),
-            'memo' => 'The <http://php.net/manual/en/ref.pdo-mysql.php>PDO MySQL</a> extension is required.'
+            'memo' => 'The <https://php.net/manual/en/ref.pdo-mysql.php>PDO MySQL</a> extension is required.'
         );
         if ($conn !== false) {
             $requirements[] = array(
@@ -43,7 +43,7 @@ switch ($this->dbDriver) {
             'name' => 'PDO PostgreSQL extension',
             'mandatory' => true,
             'condition' => extension_loaded('pdo_pgsql'),
-            'memo' => 'The <https://secure.php.net/manual/en/ref.pdo-pgsql.php>PDO PostgreSQL</a> extension is required.'
+            'memo' => 'The <https://php.net/manual/en/ref.pdo-pgsql.php>PDO PostgreSQL</a> extension is required.'
         );
         if ($conn !== false) {
             $requirements[] = array(
@@ -66,80 +66,80 @@ $requirements = array_merge($requirements, array(
         'name' => 'Reflection extension',
         'mandatory' => true,
         'condition' => extension_loaded('reflection'),
-        'memo' => 'The <a rel="noopener" target="_blank" href="http://php.net/manual/en/class.reflectionextension.php">Reflection</a> extension is required.',
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/class.reflectionextension.php">Reflection</a> extension is required.',
     ),
     array(
         'name' => 'PCRE extension (with UTF-8 support)',
         'mandatory' => true,
         'condition' => extension_loaded('pcre') && preg_match('/./u', 'Ü') === 1,
-        'memo' => 'The <a rel="noopener" target="_blank" href="http://php.net/manual/en/book.pcre.php">PCRE</a> extension is required and it must be compiled to support UTF-8.',
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.pcre.php">PCRE</a> extension is required and it must be compiled to support UTF-8.',
     ),
     array(
         'name' => 'SPL extension',
         'mandatory' => true,
         'condition' => extension_loaded('SPL'),
-        'memo' => 'The <a rel="noopener" target="_blank" href="http://php.net/manual/en/book.spl.php">SPL</a> extension is required.'
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.spl.php">SPL</a> extension is required.'
     ),
     array(
         'name' => 'PDO extension',
         'mandatory' => true,
         'condition' => extension_loaded('pdo'),
-        'memo' => 'The <a rel="noopener" target="_blank" href="http://php.net/manual/en/book.pdo.php">PDO</a> extension is required.'
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.pdo.php">PDO</a> extension is required.'
     ),
     array(
         'name' => 'Multibyte String extension (with Function Overloading disabled)',
         'mandatory' => true,
         'condition' => extension_loaded('mbstring') && ini_get('mbstring.func_overload') == 0,
-        'memo' => 'Craft CMS requires the <a rel="noopener" target="_blank" href="http://www.php.net/manual/en/book.mbstring.php">Multibyte String</a> extension with <a rel="noopener" target="_blank" href="http://php.net/manual/en/mbstring.overload.php">Function Overloading</a> disabled in order to run.'
+        'memo' => 'Craft CMS requires the <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.mbstring.php">Multibyte String</a> extension with <a rel="noopener" target="_blank" href="https://php.net/manual/en/mbstring.overload.php">Function Overloading</a> disabled in order to run.'
     ),
     array(
         'name' => 'GD extension or ImageMagick extension',
         'mandatory' => true,
         'condition' => extension_loaded('gd') || (extension_loaded('imagick') && !empty(\Imagick::queryFormats())),
-        'memo' => 'The <a rel="noopener" target="_blank" href="http://php.net/manual/en/book.image.php">GD</a> or <a rel="noopener" target="_blank" href="http://php.net/manual/en/book.imagick.php">ImageMagick</a> extension is required, however ImageMagick is recommended as it adds animated GIF support, and preserves 8-bit and 24-bit PNGs during image transforms.'
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.image.php">GD</a> or <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.imagick.php">ImageMagick</a> extension is required, however ImageMagick is recommended as it adds animated GIF support, and preserves 8-bit and 24-bit PNGs during image transforms.'
     ),
     array(
         'name' => 'OpenSSL extension',
         'mandatory' => true,
         'condition' => extension_loaded('openssl'),
-        'memo' => 'The <a rel="noopener" target="_blank" href="http://php.net/manual/en/book.openssl.php">OpenSSL</a> extension is required.'
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.openssl.php">OpenSSL</a> extension is required.'
     ),
     array(
         'name' => 'cURL extension',
         'mandatory' => true,
         'condition' => extension_loaded('curl'),
-        'memo' => 'The <a rel="noopener" target="_blank" href="http://php.net/manual/en/book.curl.php">cURL</a> extension is required.',
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.curl.php">cURL</a> extension is required.',
     ),
     array(
         'name' => 'ctype extension',
         'mandatory' => true,
         'condition' => extension_loaded('ctype'),
-        'memo' => 'The <a rel="noopener" target="_blank" href="https://secure.php.net/manual/en/book.ctype.php">ctype</a> extension is required.',
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.ctype.php">ctype</a> extension is required.',
     ),
     $this->iniSetRequirement(),
     array(
         'name' => 'Intl extension',
         'mandatory' => false,
         'condition' => $this->checkPhpExtensionVersion('intl', '1.0.2', '>='),
-        'memo' => 'The <a rel="noopener" target="_blank" href="http://www.php.net/manual/en/book.intl.php">Intl</a> extension (version 1.0.2+) is recommended.'
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.intl.php">Intl</a> extension (version 1.0.2+) is recommended.'
     ),
     array(
         'name' => 'Fileinfo extension',
         'mandatory' => true,
         'condition' => extension_loaded('fileinfo'),
-        'memo' => 'The <a rel="noopener" target="_blank" href="http://php.net/manual/en/book.fileinfo.php">Fileinfo</a> extension required.'
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.fileinfo.php">Fileinfo</a> extension required.'
     ),
     array(
         'name' => 'DOM extension',
         'mandatory' => true,
         'condition' => extension_loaded('dom'),
-        'memo' => 'The <a rel="noopener" target="_blank" href="http://php.net/manual/en/book.dom.php">DOM</a> extension is required.',
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.dom.php">DOM</a> extension is required.',
     ),
     array(
         'name' => 'iconv extension',
         'mandatory' => true,
         'condition' => function_exists('iconv'),
-        'memo' => '<a rel="noopener" target="_blank" href="http://php.net/manual/en/book.iconv.php">iconv</a> is required for more robust character set conversion support.',
+        'memo' => '<a rel="noopener" target="_blank" href="https://php.net/manual/en/book.iconv.php">iconv</a> is required for more robust character set conversion support.',
     ),
     $this->memoryLimitRequirement(),
     $this->maxExecutionTimeRequirement(),
@@ -147,55 +147,55 @@ $requirements = array_merge($requirements, array(
         'name' => 'password_hash()',
         'mandatory' => true,
         'condition' => function_exists('password_hash'),
-        'memo' => 'The <a rel="noopener" target="_blank" href="https://secure.php.net/manual/en/function.password-hash.php">password_hash()</a> function is required so Craft can create secure passwords.',
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/function.password-hash.php">password_hash()</a> function is required so Craft can create secure passwords.',
     ),
     array(
         'name' => 'Zip extension',
         'mandatory' => true,
         'condition' => extension_loaded('zip'),
-        'memo' => 'The <a rel="noopener" target="_blank" href="https://secure.php.net/manual/en/book.zip.php">zip</a> extension is required for zip and unzip operations.',
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.zip.php">zip</a> extension is required for zip and unzip operations.',
     ),
     array(
         'name' => 'JSON extension',
         'mandatory' => true,
         'condition' => extension_loaded('json'),
-        'memo' => 'The <a rel="noopener" target="_blank" href="https://secure.php.net/manual/en/book.json.php">JSON</a> extension is required for JSON encoding and decoding.',
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.json.php">JSON</a> extension is required for JSON encoding and decoding.',
     ),
     array(
         'name' => 'proc_open()',
         'mandatory' => false,
         'condition' => function_exists('proc_open'),
-        'memo' => 'The <a rel="noopener" target="_blank" href="https://secure.php.net/manual/en/function.proc-open.php">proc_open()</a> function is required for Plugin Store operations as well as sending emails.',
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/function.proc-open.php">proc_open()</a> function is required for Plugin Store operations as well as sending emails.',
     ),
     array(
         'name' => 'proc_get_status()',
         'mandatory' => false,
         'condition' => function_exists('proc_get_status'),
-        'memo' => 'The <a rel="noopener" target="_blank" href="https://secure.php.net/manual/en/function.proc-get-status.php">proc_get_status()</a> function is required for Plugin Store operations as well as sending emails.',
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/function.proc-get-status.php">proc_get_status()</a> function is required for Plugin Store operations as well as sending emails.',
     ),
     array(
         'name' => 'proc_close()',
         'mandatory' => false,
         'condition' => function_exists('proc_close'),
-        'memo' => 'The <a rel="noopener" target="_blank" href="https://secure.php.net/manual/en/function.proc-close.php">proc_close()</a> function is required for Plugin Store operations as well as sending emails.',
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/function.proc-close.php">proc_close()</a> function is required for Plugin Store operations as well as sending emails.',
     ),
     array(
         'name' => 'proc_terminate()',
         'mandatory' => false,
         'condition' => function_exists('proc_terminate'),
-        'memo' => 'The <a rel="noopener" target="_blank" href="https://secure.php.net/manual/en/function.proc-terminate.php">proc_terminate()</a> function is required for Plugin Store operations as well as sending emails.',
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/function.proc-terminate.php">proc_terminate()</a> function is required for Plugin Store operations as well as sending emails.',
     ),
     array(
         'name' => 'allow_url_fopen',
         'mandatory' => false,
         'condition' => ini_get('allow_url_fopen'),
-        'memo' => '<a rel="noopener" target="_blank" href="https://secure.php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen">allow_url_fopen</a> must be enabled in your PHP configuration for Plugin Store and updating operations.',
+        'memo' => '<a rel="noopener" target="_blank" href="https://php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen">allow_url_fopen</a> must be enabled in your PHP configuration for Plugin Store and updating operations.',
     ),
     array(
         'name' => 'ignore_user_abort()',
         'mandatory' => false,
         'condition' => function_exists('ignore_user_abort'),
-        'memo' => '<a rel="noopener" target="_blank" href="https://www.php.net/manual/en/function.ignore-user-abort.php">ignore_user_abort()</a> must be enabled in your PHP configuration for the native web-based queue runner to work.',
+        'memo' => '<a rel="noopener" target="_blank" href="https://php.net/manual/en/function.ignore-user-abort.php">ignore_user_abort()</a> must be enabled in your PHP configuration for the native web-based queue runner to work.',
     ),
 ));
 

--- a/server/requirements/requirements.php
+++ b/server/requirements/requirements.php
@@ -25,9 +25,9 @@ switch ($this->dbDriver) {
         );
         if ($conn !== false) {
             $version = $conn->getAttribute(PDO::ATTR_SERVER_VERSION);
-            if (strpos($version, 'MariaDB') !== false) {
+            if (preg_match('/[\d.]+-([\d.]+)-\bMariaDB\b/', $version, $match)) {
                 $name = 'MariaDB';
-                $version = preg_replace('/^.*?MariaDB.*?:/', '', $version);
+                $version = $match[1];
                 $requiredVersion = $this->requiredMariaDbVersion;
                 $tzUrl = 'https://mariadb.com/kb/en/time-zones/#mysql-time-zone-tables';
             } else {
@@ -39,7 +39,7 @@ switch ($this->dbDriver) {
                 'name' => "{$name} {$requiredVersion}+",
                 'mandatory' => true,
                 'condition' => version_compare($version, $requiredVersion, '>='),
-                'memo' => "{$name} {$this->requiredMySqlVersion} or higher is required to run Craft CMS.",
+                'memo' => "{$name} {$requiredVersion} or higher is required to run Craft CMS.",
             );
             $requirements[] = array(
                 'name' => "{$name} InnoDB support",

--- a/server/requirements/requirements.php
+++ b/server/requirements/requirements.php
@@ -136,7 +136,7 @@ $requirements = array_merge($requirements, array(
     $this->iniSetRequirement(),
     array(
         'name' => 'Intl extension',
-        'mandatory' => false,
+        'mandatory' => true,
         'condition' => $this->checkPhpExtensionVersion('intl', '1.0.2', '>='),
         'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.intl.php">Intl</a> extension (version 1.0.2+) is recommended.'
     ),

--- a/server/requirements/requirements.php
+++ b/server/requirements/requirements.php
@@ -6,10 +6,10 @@
 /** @var RequirementsChecker $this */
 $requirements = array(
     array(
-        'name' => 'PHP 8.0+',
+        'name' => 'PHP 8.0.2+',
         'mandatory' => true,
-        'condition' => PHP_VERSION_ID >= 80000,
-        'memo' => 'PHP 8.0 or later is required.',
+        'condition' => PHP_VERSION_ID >= 80002,
+        'memo' => 'PHP 8.0.2 or later is required.',
     ),
 );
 

--- a/server/requirements/requirements.php
+++ b/server/requirements/requirements.php
@@ -24,23 +24,34 @@ switch ($this->dbDriver) {
             'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/ref.pdo-mysql.php">PDO MySQL</a> extension is required.'
         );
         if ($conn !== false) {
+            $version = $conn->getAttribute(PDO::ATTR_SERVER_VERSION);
+            if (strpos($version, 'MariaDB') !== false) {
+                $name = 'MariaDB';
+                $version = preg_replace('/^.*?MariaDB.*?:/', '', $version);
+                $requiredVersion = $this->requiredMariaDbVersion;
+                $tzUrl = 'https://mariadb.com/kb/en/time-zones/#mysql-time-zone-tables';
+            } else {
+                $name = 'MySQL';
+                $requiredVersion = $this->requiredMySqlVersion;
+                $tzUrl = 'https://dev.mysql.com/doc/refman/5.7/en/time-zone-support.html';
+            }
             $requirements[] = array(
-                'name' => "MySQL {$this->requiredMySqlVersion}+",
+                'name' => "{$name} {$requiredVersion}+",
                 'mandatory' => true,
-                'condition' => $this->checkDatabaseServerVersion($conn, $this->requiredMySqlVersion),
-                'memo' => "MySQL {$this->requiredMySqlVersion} or higher is required to run Craft CMS.",
+                'condition' => version_compare($version, $requiredVersion, '>='),
+                'memo' => "{$name} {$this->requiredMySqlVersion} or higher is required to run Craft CMS.",
             );
             $requirements[] = array(
-                'name' => 'MySQL InnoDB support',
+                'name' => "{$name} InnoDB support",
                 'mandatory' => true,
                 'condition' => $this->isInnoDbSupported($conn),
-                'memo' => 'Craft CMS requires the MySQL InnoDB storage engine to run.',
+                'memo' => "Craft CMS requires the {$name} InnoDB storage engine to run.",
             );
             $requirements[] = array(
-                'name' => 'MySQL timezone support',
+                'name' => "{$name} timezone support",
                 'mandatory' => false,
                 'condition' => $this->validateDatabaseTimezoneSupport($conn),
-                'memo' => 'MySQL should be configured with <a rel="noopener" target="_blank" href="https://dev.mysql.com/doc/refman/5.7/en/time-zone-support.html">full timezone support</a>.',
+                'memo' => "{$name} should be configured with <a rel='noopener' target='_blank' href='{$tzUrl}'>full timezone support</a>.",
             );
         }
         break;

--- a/server/requirements/requirements.php
+++ b/server/requirements/requirements.php
@@ -98,6 +98,12 @@ $requirements = array_merge($requirements, array(
         'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.spl.php">SPL</a> extension is required.'
     ),
     array(
+        'name' => 'BCMath extension',
+        'mandatory' => true,
+        'condition' => extension_loaded('bcmath'),
+        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.bc.php">BCMath</a> extension is required.'
+    ),
+    array(
         'name' => 'PDO extension',
         'mandatory' => true,
         'condition' => extension_loaded('pdo'),

--- a/server/requirements/requirements.php
+++ b/server/requirements/requirements.php
@@ -6,10 +6,10 @@
 /** @var RequirementsChecker $this */
 $requirements = array(
     array(
-        'name' => 'PHP 7.2.5+',
+        'name' => 'PHP 7.4+',
         'mandatory' => true,
-        'condition' => PHP_VERSION_ID >= 70205,
-        'memo' => 'PHP 7.2.5 or later is required.',
+        'condition' => PHP_VERSION_ID >= 70400,
+        'memo' => 'PHP 7.4 or later is required.',
     ),
 );
 

--- a/server/requirements/requirements.php
+++ b/server/requirements/requirements.php
@@ -117,9 +117,9 @@ $requirements = array_merge($requirements, array(
     ),
     array(
         'name' => 'GD extension or ImageMagick extension',
-        'mandatory' => true,
+        'mandatory' => false,
         'condition' => extension_loaded('gd') || (extension_loaded('imagick') && !empty(\Imagick::queryFormats())),
-        'memo' => 'The <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.image.php">GD</a> or <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.imagick.php">ImageMagick</a> extension is required, however ImageMagick is recommended as it adds animated GIF support, and preserves 8-bit and 24-bit PNGs during image transforms.'
+        'memo' => 'When using Craft\'s default image transformer, the <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.image.php">GD</a> or <a rel="noopener" target="_blank" href="https://php.net/manual/en/book.imagick.php">ImageMagick</a> extension is required. ImageMagick is recommended as it adds animated GIF support, and preserves 8-bit and 24-bit PNGs during image transforms.'
     ),
     array(
         'name' => 'OpenSSL extension',

--- a/server/requirements/requirements.php
+++ b/server/requirements/requirements.php
@@ -6,10 +6,10 @@
 /** @var RequirementsChecker $this */
 $requirements = array(
     array(
-        'name' => 'PHP 7.4+',
+        'name' => 'PHP 8.0+',
         'mandatory' => true,
-        'condition' => PHP_VERSION_ID >= 70400,
-        'memo' => 'PHP 7.4 or later is required.',
+        'condition' => PHP_VERSION_ID >= 80000,
+        'memo' => 'PHP 8.0 or later is required.',
     ),
 );
 

--- a/server/views/web/css.php
+++ b/server/views/web/css.php
@@ -4,7 +4,7 @@
  *
  * Copyright 2013 Twitter, Inc
  * Licensed under the Apache License v2.0
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Designed and built with all the love in the world by @mdo and @fat.
  */


### PR DESCRIPTION
Moving to replace `main` with the most current version of the tool, 2.0.


Upon the release of Craft 4, we ought to have merged `2.0` into `main` and deleted `2.0`.