### PR TITLE
Fix warning under PHP 8.1+

### DIFF
--- a/server/requirements/RequirementsChecker.php
+++ b/server/requirements/RequirementsChecker.php
@@ -386,7 +386,7 @@ class RequirementsChecker
 
         if ($conn === null) {
             try {
-                $conn = new PDO($this->dsn, $this->dbUser, $this->dbPassword);
+                $conn = new PDO($this->dsn ?? '', $this->dbUser, $this->dbPassword);
                 $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
             } catch (PDOException $e) {
                 $conn = false;


### PR DESCRIPTION
### Description
Under PHP 8.1 and 8.2, checkit.php displayed a warning: "Deprecated: PDO::__construct(): Passing null to parameter #1 ($dsn) of type string is deprecated". Fixed it.

### Related issues

