### PR TITLE
Check global aliases for @web

### DIFF
--- a/server/requirements/RequirementsChecker.php
+++ b/server/requirements/RequirementsChecker.php
@@ -544,7 +544,7 @@ class RequirementsChecker
      */
     function webAliasRequirement()
     {
-        $aliases = Craft::$app->getConfig()->getGeneral()->aliases;
+        $aliases = Craft::$aliases;
         $memo = 'We recommend explicitly overriding the <a rel="noopener" target="_blank" href="https://craftcms.com/docs/4.x/config/#aliases">@web alias</a>.';
         $pass = false;
 


### PR DESCRIPTION
### Description
Checks `Craft::$aliases` for web alias, instead of just aliases from GeneralConfig