### PR TITLE
remove max_execution_time requirement

### DIFF
--- a/server/requirements/RequirementsChecker.php
+++ b/server/requirements/RequirementsChecker.php
@@ -521,26 +521,6 @@ class RequirementsChecker
 
     /**
      * @return array
-     *
-     * @see https://php.net/manual/en/info.configuration.php#ini.max-execution-time
-     */
-    function maxExecutionTimeRequirement()
-    {
-        $maxExecutionTime = (int)trim(ini_get('max_execution_time'));
-
-        $humanTime = $maxExecutionTime . ($maxExecutionTime === 0 ? ' (no limit)' : '');
-        $memo = "Craft requires a minimum PHP max execution time of 120 seconds. The max_execution_time directive in php.ini is currently set to {$humanTime}.";
-
-        return array(
-            'name' => 'Max Execution Time',
-            'mandatory' => false,
-            'condition' => $maxExecutionTime === 0 || $maxExecutionTime >= 120,
-            'memo' => $memo,
-        );
-    }
-
-    /**
-     * @return array
      */
     function webAliasRequirement()
     {

--- a/server/requirements/requirements.php
+++ b/server/requirements/requirements.php
@@ -233,7 +233,6 @@ $requirements = array_merge($requirements, array_filter(array(
 
     $this->iniSetRequirement(),
     $this->memoryLimitRequirement(),
-    $this->maxExecutionTimeRequirement(),
 )));
 
 return $requirements;


### PR DESCRIPTION
This requirement doesn't make much sense.

In general, a 120 sec timeout for a web request is a bad idea, and is well beyond the default for PHP, nginx, and apache – meaning almost nobody is going to meet this soft requirement.

PHP cli by default won't have a time limit, so the point is moot there.

Instead of this, we should just stress more that best practice is running your queue via cli. For those still using a web queue, batched jobs should help with anyone having timeouts.