### PR TITLE
Update MariaDB regex to account for strings like “10.11.13-MariaDB-0ubuntu0.24.04”

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for Craft CMS Server Check
 
+## Unreleased
+- Fixed a bug where MariaDB versions weren’t always getting parsed correctly. ([craftcms/cms#17639](https://github.com/craftcms/cms/issues/17639))
+
 ## 2.1.10 - 2025-02-11
 - Fixed a bug where the MySQL timezone support check could return a false negative on some servers.
 

--- a/server/requirements/requirements.php
+++ b/server/requirements/requirements.php
@@ -28,7 +28,7 @@ switch ($this->dbDriver) {
         if ($conn !== false) {
             $version = $conn->getAttribute(PDO::ATTR_SERVER_VERSION);
             // https://github.com/craftcms/cms/issues/17639#issuecomment-3097592753
-            if (preg_match('/[\d.]+(-[\d.]+)?-\bMariaDB\b/', $version, $match)) {
+            if (preg_match('/([\d.]+)-MariaDB\b/', $version, $match)) {
                 $name = 'MariaDB';
                 $version = $match[1];
                 $requiredVersion = $this->requiredMariaDbVersion;

--- a/server/requirements/requirements.php
+++ b/server/requirements/requirements.php
@@ -27,7 +27,8 @@ switch ($this->dbDriver) {
         );
         if ($conn !== false) {
             $version = $conn->getAttribute(PDO::ATTR_SERVER_VERSION);
-            if (preg_match('/[\d.]+-([\d.]+)-\bMariaDB\b/', $version, $match)) {
+            // https://github.com/craftcms/cms/issues/17639#issuecomment-3097592753
+            if (preg_match('/[\d.]+(-[\d.]+)?-\bMariaDB\b/', $version, $match)) {
                 $name = 'MariaDB';
                 $version = $match[1];
                 $requiredVersion = $this->requiredMariaDbVersion;


### PR DESCRIPTION
Fixes https://github.com/craftcms/cms/issues/17639#issuecomment-3097592753